### PR TITLE
Filter case-insensitively, handle numbers as text

### DIFF
--- a/bbGrid.js
+++ b/bbGrid.js
@@ -733,7 +733,7 @@ _.extend(bbGrid.FilterView.prototype, Backbone.View.prototype, {
         if(text.length > 0)
             collection.reset(_.filter(collection.models, function(model){
                 var option = model.get(key);
-                if(option) return option.indexOf(text) >= 0;
+                if(option) return ("" + option).toLowerCase().indexOf(text.toLowerCase()) >= 0;
                 else return false;
             }),{silent: true});
         this.filter(collection, options);


### PR DESCRIPTION
Filter is case sensitive which can be inconvenient, and columns which represent numeric properties of the model cannot be searched.  This commit fixes both issues.

Great start to this library, by the way!  I'll be keeping an eye on it for sure.
