### PR TITLE
stringComparator: handle missing model attributes

### DIFF
--- a/bbGrid.js
+++ b/bbGrid.js
@@ -120,7 +120,7 @@ _.extend(bbGrid.View.prototype, Backbone.View.prototype, {
         return model.get(this.sortName);
     },
     stringComparator: function(model){
-        return model.get(this.sortName).toLowerCase();
+        return ("" + model.get(this.sortName)).toLowerCase();
     },
     rsortBy: function(col){        
         var isSort = (this.sortName && this.sortName == col.name) ? false: true;


### PR DESCRIPTION
When model attributes are not present on every model in the grid's collection, sorting fails on the first try.  This commit resolves this error so sorting works from the first click regardless of attribute presence.
