### PR TITLE
fix error

### DIFF
--- a/bbGrid.js
+++ b/bbGrid.js
@@ -32,7 +32,7 @@ bbGrid.View = function (options) {
     _.bindAll(this, 'numberComparator', 'stringComparator');
     this.on('all', this.EventHandler, this);
     this.rowViews = {};
-    this.selectedRows = [];
+    this.selectedRows = this.selectedRows || [];
     this.currPage = 1;
     if (!this.collection) {
         throw ('bbGrid: collection is undefined');
@@ -376,7 +376,6 @@ _.extend(bbGrid.View.prototype, Backbone.View.prototype, {
             });
             return false;
         }
-        this.selectedRows = [];
         if (this.onBeforeRender) {
             this.onBeforeRender();
         }


### PR DESCRIPTION
- Do not hide the loading view when collection.length === 0

```
new bbGrid.View({
        container: $('#bbGrid-clear'),
        collection: new Backbone.Collection([]),
        colModel: [
                { title: 'ID', name: 'id' },
                { title: 'Full Name', name: 'name'},
                { title: 'Company', name: 'company'},
                { title: 'Email', name: 'email' }
        ]
});
```
- Do not select the selected rows when set selectedRows values.

```
new bbGrid.View({
        container: $('#bbGrid-clear'),
        collection: new Backbone.Collection([
                {id: 1, name: 'wenzhixin', company: 'scutech', email: 'wenzhixin
        ]),
        selectedRows: [1],
        multiselect: true,
        colModel: [
                { title: 'ID', name: 'id' },
                { title: 'Full Name', name: 'name'},
                { title: 'Company', name: 'company'},
                { title: 'Email', name: 'email' }
        ]
});
```
