### PR TITLE
remove container class and add resetAllcheckbox function

### DIFF
--- a/bbGrid.js
+++ b/bbGrid.js
@@ -567,7 +567,7 @@ _.extend(bbGrid.RowView.prototype, Backbone.View.prototype, {
         if (this.view.onRowClick) {
             this.view.onRowClick(this.model, options);
         }
-		this.view.thead.resetAllcheckbox();
+        this.view.thead.resetAllcheckbox();
     },
     render: function () {
         var self = this, row, cols, isChecked, isDisabled, html;
@@ -742,9 +742,9 @@ _.extend(bbGrid.TheadView.prototype, Backbone.View.prototype, {
         return this.$el;
     },
     resetAllcheckbox: function () {
-    	var rows = $('.bbGrid-row input[type=checkbox]', this.view.$el).length,
-    		checkedRows = $('.bbGrid-row input[type=checkbox]:checked', this.view.$el).length;
-    	$('input[type=checkbox]', this.$el).prop('checked', checkedRows === rows);
+        var rows = $('.bbGrid-row input[type=checkbox]', this.view.$el).length,
+            checkedRows = $('.bbGrid-row input[type=checkbox]:checked', this.view.$el).length;
+        $('input[type=checkbox]', this.$el).prop('checked', checkedRows === rows);
     }
 });
 


### PR DESCRIPTION
### 1. remove container class

The bbGrid display error when I add bootstrap-responsive.css link.
- css: 

```
...
<link rel="stylesheet" href="stylesheets/bbGrid.css" />
<link rel="stylesheet" href="http://twitter.github.com/bootstrap/assets/css/bootstrap-responsive.css" />
```
- html:

```
<div class="row">
  <div class="span4">left</div>
  <div id="bbGrid-clear" class="span8"></div>
</div>
```
### 2. add resetAllcheckbox() function for thead view
- test example1:

```
new bbGrid.View({
    container: $('#bbGrid-clear'),
    collection: new Backbone.Collection([
        {id: 1, name: 'wenzhixin', company: 'scutech', email: 'wenzhixin2010@gmail.com'},
        {id: 2, name: 'wenzhixin', company: 'scutech', email: 'wenzhixin2010@gmail.com'}
    ]),
    selectedRows: [1, 2],
    multiselect: true,
    colModel: [
        { title: 'ID', name: 'id' },
        { title: 'Full Name', name: 'name'},
        { title: 'Company', name: 'company'},
        { title: 'Email', name: 'email' }
    ]
});
```
- test example2:

```
new bbGrid.View({
    container: $('#bbGrid-clear'),
    collection: new Backbone.Collection([
        {id: 1, name: 'wenzhixin', company: 'scutech', email: 'wenzhixin2010@gmail.com'},
        {id: 2, name: 'wenzhixin', company: 'scutech', email: 'wenzhixin2010@gmail.com'},
        {id: 3, name: 'wenzhixin', company: 'scutech', email: 'wenzhixin2010@gmail.com'},
        {id: 4, name: 'wenzhixin', company: 'scutech', email: 'wenzhixin2010@gmail.com'},
        {id: 5, name: 'wenzhixin', company: 'scutech', email: 'wenzhixin2010@gmail.com'},
        {id: 6, name: 'wenzhixin', company: 'scutech', email: 'wenzhixin2010@gmail.com'}
    ]),
    selectedRows: [1, 2],
    multiselect: true,
    rows: 4,
    colModel: [
        { title: 'ID', name: 'id' },
        { title: 'Full Name', name: 'name'},
        { title: 'Company', name: 'company'},
        { title: 'Email', name: 'email' }
    ]
});
```
