### PR TITLE
Ensure that _.templateSettings are set correctly.

### DIFF
--- a/bbGrid.js
+++ b/bbGrid.js
@@ -5,7 +5,12 @@
 //     For all details and documentation:
 //     http://direct-fuel-injection.github.com/bbGrid/
 (function () {
-    var viewOptions,
+    var templateSettings = {
+			evaluate    : /<%([\s\S]+?)%>/g,
+			interpolate : /<%=([\s\S]+?)%>/g,
+			escape      : /<%-([\s\S]+?)%>/g
+		};
+	var viewOptions,
         bbGrid = this.bbGrid = {
             'VERSION': '0.8.2',
             'lang': 'en',
@@ -341,7 +346,7 @@
             }
             $('td.bbGrid-subgrid-control i', $el).addClass('icon-minus');
             colspan = this.multiselect ? 2 : 1;
-            subgridRow = _.template('<tr class="bbGrid-subgrid-row"><td colspan="<%=extra%>"/><td colspan="<%=colspan %>"></td></tr>');
+            subgridRow = _.template('<tr class="bbGrid-subgrid-row"><td colspan="<%=extra%>"/><td colspan="<%=colspan %>"></td></tr>', null, templateSettings);
             subgridContainerHtml = subgridRow({ extra: colspan, colspan: this.colLength - colspan });
             View.$subgridContainer = $(subgridContainerHtml);
             $el.after(View.$subgridContainer);
@@ -530,7 +535,7 @@
                 <td <% if (row.name === "bbGrid-actions-cell") {%>class="bbGrid-actions-cell"<%}%>>\
                     <%=row.value%>\
                 </td>\
-            <%})%>'
+            <%})%>', null, templateSettings
         ),
         modelRemoved: function (model) {
             var self = this,
@@ -669,7 +674,7 @@
                         <option <% if (rows === val) {%>selected="selected"<%}%>><%=val%></option>\
                     <%})%>\
                 </select>\
-            <%}%>'
+            <%}%>', null, templateSettings)
         ),
         onRowsChanged: function (event) {
             this.view.rows = parseInt($(event.target).val(), 10);
@@ -729,7 +734,7 @@
                     <th <%if (col.width) {%>style="width:<%=col.width%>"<%}%>><%=col.title%><i <% \
                         if (col.sortOrder === "asc" ) {%>class="icon-chevron-up"<%} else \
                             if (col.sortOrder === "desc" ) {%>class="icon-chevron-down"<% } %>/></th>\
-            <%})%>'
+            <%})%>', null, templateSettings
         ),
         onAllCheckbox: function (event) {
             this.view.trigger('checkall', event);
@@ -779,7 +784,7 @@
                     if (!button) {
                         return undefined;
                     }
-                    btn = _.template('<button <%if (id) {%>id="<%=id%>"<%}%> class="btn btn-mini" type="button"><%=title%></button>');
+                    btn = _.template('<button <%if (id) {%>id="<%=id%>"<%}%> class="btn btn-mini" type="button"><%=title%></button>', null, templateSettings);
                     btnHtml = button.html || btn({id: button.id, title: button.title});
                     $button = $(btnHtml).appendTo(self.view.$buttonsContainer);
                     if (button.onClick) {
@@ -829,7 +834,7 @@
                         <%})%>\
                     </ul>\
                 </div>\
-            </div>'
+            </div>', null, templateSettings
         ),
         initialize: function (options) {
             _.bindAll(this, 'setSearchOption');
@@ -906,7 +911,7 @@
                     </select><%}%>\
                     <%}%>\
                 </td>\
-            <%})%>'),
+            <%})%>', null, templateSettings),
         initialize: function (options) {
             options.view._collection = options.view.collection;
             options.view.filterOptions = {};


### PR DESCRIPTION
If _.templateSettings are overridden to change the syntax (i.e. handlebars) by another library, then the templating settings are broken for bbGrid which relies upon the default template settings.

// Underscore Default
_.templateSettings = {
  evaluate    : /<%([\s\S]+?)%>/g,
  interpolate : /<%=([\s\S]+?)%>/g,
  escape      : /<%-([\s\S]+?)%>/g
};

// Handlebars like syntax
_.templateSettings = {
  interpolate: /{{(.+?)}}/g,
  evaluate: /[[(.+?)]]/g
};
